### PR TITLE
Fix intermediate table name in data model documentation

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -142,12 +142,12 @@ erDiagram
 PlayLog と DailyCategoryResult は暗黙的な多対多関係を持つ。
 Prismaでは明示的な中間テーブルを使用する。
 
-**中間テーブル: _PlayLogToDailyCategoryResult**
+**中間テーブル: _DailyCategoryResultToPlayLog**
 
 | カラム | 型 | 説明 |
 |--------|-----|------|
-| A | String | PlayLog.id |
-| B | String | DailyCategoryResult.id |
+| A | String | DailyCategoryResult.id |
+| B | String | PlayLog.id |
 
 **Prismaスキーマ例:**
 


### PR DESCRIPTION
## Summary
- Correct the implicit many-to-many relation table name from `_PlayLogToDailyCategoryResult` to `_DailyCategoryResultToPlayLog`
- Swap A/B column descriptions to match Prisma's alphabetical ordering convention

## Test plan
- [x] Verify documentation matches Prisma's naming convention (alphabetical order: DailyCategoryResult < PlayLog)
- [x] Confirm A column references DailyCategoryResult.id and B column references PlayLog.id

🤖 Generated with [Claude Code](https://claude.com/claude-code)