### PR TITLE
feat(api): Add SkillTree API with trees, nodes, and seasonal titles

### DIFF
--- a/src/app/api/skills/nodes/[id]/unlock/route.ts
+++ b/src/app/api/skills/nodes/[id]/unlock/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { skillNodeIdParamSchema } from '@/lib/validations/skill'
+import {
+  formatInternalError,
+  formatNotFoundError,
+  formatZodError,
+} from '@/lib/validations/helpers'
+
+type InvalidOperationDetails = Record<string, unknown> | undefined
+
+function formatInvalidOperation(message: string, details?: InvalidOperationDetails) {
+  return NextResponse.json(
+    {
+      error: {
+        code: 'INVALID_OPERATION',
+        message,
+        details,
+      },
+    },
+    { status: 400 }
+  )
+}
+
+/**
+ * POST /api/skills/nodes/:id/unlock
+ * スキルノードを解放
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id?: string }> }
+) {
+  try {
+    const { id } = await params
+    const result = skillNodeIdParamSchema.safeParse({ id: id ?? '' })
+
+    if (!result.success) {
+      return formatZodError(result.error)
+    }
+
+    const node = await prisma.skillNode.findUnique({
+      where: { id: result.data.id },
+      include: {
+        tree: {
+          select: {
+            id: true,
+            categoryId: true,
+            category: {
+              select: {
+                playerState: {
+                  select: {
+                    id: true,
+                    categoryId: true,
+                    xpTotal: true,
+                    spUnspent: true,
+                    createdAt: true,
+                    updatedAt: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        unlockedNodes: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    })
+
+    if (!node) {
+      return formatNotFoundError('スキルノード', result.data.id)
+    }
+
+    if (node.unlockedNodes.length > 0) {
+      return formatInvalidOperation('既に解放済みです')
+    }
+
+    const playerState = node.tree.category.playerState
+    if (!playerState) {
+      return formatInvalidOperation('プレイヤー状態が存在しません')
+    }
+
+    if (playerState.spUnspent < node.costSp) {
+      return formatInvalidOperation('SPが不足しています', {
+        requiredSp: node.costSp,
+        currentSp: playerState.spUnspent,
+      })
+    }
+
+    if (node.order > 1) {
+      const prevNode = await prisma.skillNode.findUnique({
+        where: {
+          treeId_order: {
+            treeId: node.treeId,
+            order: node.order - 1,
+          },
+        },
+        include: {
+          unlockedNodes: {
+            select: { id: true },
+          },
+        },
+      })
+
+      if (!prevNode || prevNode.unlockedNodes.length === 0) {
+        return formatInvalidOperation('前提ノードが解放されていません')
+      }
+    }
+
+    const unlockResult = await prisma.$transaction(async (tx) => {
+      const updatedPlayerState = await tx.playerCategoryState.update({
+        where: { categoryId: node.tree.categoryId },
+        data: { spUnspent: { decrement: node.costSp } },
+        select: {
+          id: true,
+          categoryId: true,
+          xpTotal: true,
+          spUnspent: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })
+
+      const unlockedNode = await tx.unlockedNode.create({
+        data: { nodeId: node.id },
+        select: {
+          id: true,
+          nodeId: true,
+          unlockedAt: true,
+        },
+      })
+
+      const spendLog = await tx.spendLog.create({
+        data: {
+          categoryId: node.tree.categoryId,
+          type: 'unlock_node',
+          costSp: node.costSp,
+          refId: node.id,
+        },
+        select: {
+          id: true,
+          at: true,
+          categoryId: true,
+          type: true,
+          costSp: true,
+          refId: true,
+          dayKey: true,
+          createdAt: true,
+        },
+      })
+
+      return { updatedPlayerState, unlockedNode, spendLog }
+    })
+
+    return NextResponse.json({
+      playerState: unlockResult.updatedPlayerState,
+      unlockedNode: unlockResult.unlockedNode,
+      spendLog: unlockResult.spendLog,
+    })
+  } catch (error) {
+    console.error('Failed to unlock skill node:', error)
+    return formatInternalError('スキルノードの解放に失敗しました')
+  }
+}

--- a/src/app/api/skills/nodes/route.ts
+++ b/src/app/api/skills/nodes/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { skillNodesQuerySchema } from '@/lib/validations/skill'
+import {
+  formatInternalError,
+  formatNotFoundError,
+  formatZodError,
+} from '@/lib/validations/helpers'
+
+/**
+ * GET /api/skills/nodes
+ * スキルノード一覧を取得
+ * クエリパラメータ:
+ *   - treeId: 対象ツリーID（必須）
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const query = {
+      treeId: searchParams.get('treeId') ?? '',
+    }
+    const result = skillNodesQuerySchema.safeParse(query)
+
+    if (!result.success) {
+      return formatZodError(result.error)
+    }
+
+    const tree = await prisma.skillTree.findUnique({
+      where: { id: result.data.treeId },
+      select: { id: true },
+    })
+
+    if (!tree) {
+      return formatNotFoundError('スキルツリー', result.data.treeId)
+    }
+
+    const skillNodes = await prisma.skillNode.findMany({
+      where: { treeId: result.data.treeId },
+      orderBy: [{ order: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        treeId: true,
+        order: true,
+        title: true,
+        costSp: true,
+        createdAt: true,
+        updatedAt: true,
+        unlockedNodes: {
+          select: {
+            id: true,
+            nodeId: true,
+            unlockedAt: true,
+          },
+        },
+      },
+    })
+
+    return NextResponse.json({ skillNodes })
+  } catch (error) {
+    console.error('Failed to fetch skill nodes:', error)
+    return formatInternalError('スキルノードの取得に失敗しました')
+  }
+}

--- a/src/app/api/skills/seasonal-titles/current/route.ts
+++ b/src/app/api/skills/seasonal-titles/current/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getRecentDayKeys } from '@/lib/date'
+import { seasonalTitlesQuerySchema } from '@/lib/validations/skill'
+import {
+  formatInternalError,
+  formatNotFoundError,
+  formatZodError,
+} from '@/lib/validations/helpers'
+
+/**
+ * GET /api/skills/seasonal-titles/current
+ * 現在の週ランク称号を取得
+ * クエリパラメータ:
+ *   - categoryId: 対象カテゴリID（必須）
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const query = {
+      categoryId: searchParams.get('categoryId') ?? '',
+    }
+    const result = seasonalTitlesQuerySchema.safeParse(query)
+
+    if (!result.success) {
+      return formatZodError(result.error)
+    }
+
+    const category = await prisma.category.findUnique({
+      where: { id: result.data.categoryId },
+      select: { id: true, rankWindowDays: true },
+    })
+
+    if (!category) {
+      return formatNotFoundError('カテゴリ', result.data.categoryId)
+    }
+
+    const recentDayKeys = getRecentDayKeys(category.rankWindowDays)
+    const recentSpAggregate = recentDayKeys.length
+      ? await prisma.dailyCategoryResult.aggregate({
+          where: {
+            categoryId: result.data.categoryId,
+            dayKey: { in: recentDayKeys },
+          },
+          _sum: { spEarned: true },
+        })
+      : { _sum: { spEarned: 0 } }
+
+    const recentSp = recentSpAggregate._sum.spEarned ?? 0
+
+    const seasonalTitles = await prisma.seasonalTitle.findMany({
+      where: { categoryId: result.data.categoryId },
+      orderBy: [{ order: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        categoryId: true,
+        label: true,
+        minSpEarned: true,
+        order: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+
+    const currentTitle = seasonalTitles
+      .filter((title) => title.minSpEarned <= recentSp)
+      .sort((a, b) => b.order - a.order || b.minSpEarned - a.minSpEarned)[0]
+
+    return NextResponse.json({
+      currentTitle: currentTitle ?? null,
+      recentSp,
+      rankWindowDays: category.rankWindowDays,
+    })
+  } catch (error) {
+    console.error('Failed to fetch current seasonal title:', error)
+    return formatInternalError('現在の週ランク称号の取得に失敗しました')
+  }
+}

--- a/src/app/api/skills/seasonal-titles/route.ts
+++ b/src/app/api/skills/seasonal-titles/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { seasonalTitlesQuerySchema } from '@/lib/validations/skill'
+import {
+  formatInternalError,
+  formatNotFoundError,
+  formatZodError,
+} from '@/lib/validations/helpers'
+
+/**
+ * GET /api/skills/seasonal-titles
+ * 週ランク称号一覧を取得
+ * クエリパラメータ:
+ *   - categoryId: 対象カテゴリID（必須）
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const query = {
+      categoryId: searchParams.get('categoryId') ?? '',
+    }
+    const result = seasonalTitlesQuerySchema.safeParse(query)
+
+    if (!result.success) {
+      return formatZodError(result.error)
+    }
+
+    const category = await prisma.category.findUnique({
+      where: { id: result.data.categoryId },
+      select: { id: true },
+    })
+
+    if (!category) {
+      return formatNotFoundError('カテゴリ', result.data.categoryId)
+    }
+
+    const seasonalTitles = await prisma.seasonalTitle.findMany({
+      where: { categoryId: result.data.categoryId },
+      orderBy: [{ order: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        categoryId: true,
+        label: true,
+        minSpEarned: true,
+        order: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+
+    return NextResponse.json({ seasonalTitles })
+  } catch (error) {
+    console.error('Failed to fetch seasonal titles:', error)
+    return formatInternalError('週ランク称号の取得に失敗しました')
+  }
+}

--- a/src/app/api/skills/trees/route.ts
+++ b/src/app/api/skills/trees/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { skillTreesQuerySchema } from '@/lib/validations/skill'
+import {
+  formatInternalError,
+  formatNotFoundError,
+  formatZodError,
+} from '@/lib/validations/helpers'
+
+/**
+ * GET /api/skills/trees
+ * スキルツリー一覧を取得
+ * クエリパラメータ:
+ *   - categoryId: 対象カテゴリID（必須）
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const query = {
+      categoryId: searchParams.get('categoryId') ?? '',
+    }
+    const result = skillTreesQuerySchema.safeParse(query)
+
+    if (!result.success) {
+      return formatZodError(result.error)
+    }
+
+    const category = await prisma.category.findUnique({
+      where: { id: result.data.categoryId },
+      select: { id: true },
+    })
+
+    if (!category) {
+      return formatNotFoundError('カテゴリ', result.data.categoryId)
+    }
+
+    const skillTrees = await prisma.skillTree.findMany({
+      where: { categoryId: result.data.categoryId },
+      orderBy: [{ order: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        categoryId: true,
+        name: true,
+        visible: true,
+        order: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+
+    return NextResponse.json({ skillTrees })
+  } catch (error) {
+    console.error('Failed to fetch skill trees:', error)
+    return formatInternalError('スキルツリーの取得に失敗しました')
+  }
+}

--- a/src/lib/validations/skill.ts
+++ b/src/lib/validations/skill.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+const requiredId = (label: string) =>
+  z
+    .string({ required_error: `${label}は必須です` })
+    .trim()
+    .min(1, `${label}は必須です`)
+
+export const skillTreesQuerySchema = z.object({
+  categoryId: requiredId('カテゴリID'),
+})
+
+export const skillNodesQuerySchema = z.object({
+  treeId: requiredId('ツリーID'),
+})
+
+export const skillNodeIdParamSchema = z.object({
+  id: requiredId('ノードID'),
+})
+
+export const seasonalTitlesQuerySchema = z.object({
+  categoryId: requiredId('カテゴリID'),
+})
+
+export type SkillTreesQueryInput = z.infer<typeof skillTreesQuerySchema>
+export type SkillNodesQueryInput = z.infer<typeof skillNodesQuerySchema>
+export type SkillNodeIdParamInput = z.infer<typeof skillNodeIdParamSchema>
+export type SeasonalTitlesQueryInput = z.infer<typeof seasonalTitlesQuerySchema>


### PR DESCRIPTION
## Summary
- Add comprehensive SkillTree API endpoints for skill progression system
- Implement GET /api/skills/trees to list skill trees by category
- Implement GET /api/skills/nodes to list skill nodes by tree
- Implement POST /api/skills/nodes/:id/unlock to unlock skill nodes with SP cost validation and prerequisite checks
- Implement GET /api/skills/seasonal-titles to list seasonal titles by category
- Implement GET /api/skills/seasonal-titles/current to get current title based on recent SP earned

## Test plan
- [ ] Verify GET /api/skills/trees returns skill trees filtered by categoryId
- [ ] Verify GET /api/skills/nodes returns nodes filtered by treeId with unlock status
- [ ] Verify POST /api/skills/nodes/:id/unlock correctly validates SP balance
- [ ] Verify POST /api/skills/nodes/:id/unlock enforces prerequisite node requirements
- [ ] Verify GET /api/skills/seasonal-titles returns titles filtered by categoryId
- [ ] Verify GET /api/skills/seasonal-titles/current calculates current title based on rankWindowDays

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)