### PR TITLE
fix: tsconfig.jsonからprisma/seed.tsを除外しVercelビルドエラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "db:generate": "prisma generate",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,11 +25,7 @@
       {
         "name": "next"
       }
-    ],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    ]
   },
   "include": [
     "next-env.d.ts",
@@ -41,6 +37,7 @@
   ],
   "exclude": [
     "node_modules",
-    "vitest.config.ts"
+    "vitest.config.ts",
+    "prisma/seed.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
   "exclude": [
     "node_modules",
     "vitest.config.ts",
-    "prisma/seed.ts"
+    "prisma/seed.ts",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## Summary
- `prisma/seed.ts` を `tsconfig.json` の `exclude` に追加し、Vercelデプロイ時のビルドエラー（`PrismaClient` インポートエラー）を修正
- 重複していた `baseUrl` / `paths` の定義を整理

## Test plan
- [ ] Vercelでのビルドが成功することを確認
- [ ] ローカルで `pnpm run build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)