### PR TITLE
docs: Prisma マイグレーション禁止と db pull 同期手順を明記 (LIF-34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,6 @@ npm run db:studio
 # スキーマを levup-api の変更に合わせて同期（このリポジトリでのスキーマ変更方法）
 npx prisma db pull
 npm run db:generate
-
-# Prisma Clientを再生成
-npm run db:generate
 ```
 
 > ~~`npm run db:migrate`~~ — 禁止。スキーマ変更は levup-api で行うこと。

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ mise run db
 
 ### データベース関連
 
+> **マイグレーション禁止**: このリポジトリでは `prisma migrate` および `prisma db push` を実行しないでください。
+> スキーマ変更は **levup-api リポジトリ** で行い、このリポジトリは `npx prisma db pull` で同期します。
+
 ```bash
 # DBをDockerで起動
 npm run docker:up
@@ -140,15 +143,16 @@ npm run docker:down
 # Prisma Studio（DBビューア）を起動
 npm run db:studio
 
-# マイグレーションを作成・適用
-npm run db:migrate
-
-# スキーマをDBにプッシュ（開発用）
-npm run db:push
+# スキーマを levup-api の変更に合わせて同期（このリポジトリでのスキーマ変更方法）
+npx prisma db pull
+npm run db:generate
 
 # Prisma Clientを再生成
 npm run db:generate
 ```
+
+> ~~`npm run db:migrate`~~ — 禁止。スキーマ変更は levup-api で行うこと。
+> ~~`npm run db:push`~~ — 禁止。同上。
 
 ### 開発
 


### PR DESCRIPTION
## Summary

- `README.md` のデータベース関連セクションに **マイグレーション禁止の警告** を追加
- スキーマ変更は levup-api で行い、`npx prisma db pull` で同期するルールを明記
- 誤って `npm run db:migrate` / `npm run db:push` を実行しないよう取り消し線で明示

## 背景

`prisma/schema.prisma` が levup-api と life-game-rpg の両リポジトリに存在しており、
どちらからでも `prisma migrate` を実行できる状態は本番 DB の破壊リスクがある。
levup-api をスキーマの正とし、このリポジトリは参照のみとするルールをドキュメントに記載する。

## 関連

- Linear: [LIF-34](https://linear.app/lifeblueprint/issue/LIF-34)
- levup-api 側の対応 PR: mkoichi0510/levup-api#feature/lif-34-prisma-migration-docs

## Test plan

- [ ] README のデータベース関連セクションに禁止注記が表示されることを確認
- [ ] `npx prisma db pull` の手順が明記されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)