### PR TITLE
docs: spec-doc Skill 検証 — 5 feature の仕様書を生成 (LIF-66)

### DIFF
--- a/docs/action-api/overview.md
+++ b/docs/action-api/overview.md
@@ -1,0 +1,47 @@
+# Action API Overview
+
+> 高位概要。詳細は [`./spec.md`](./spec.md) を参照。
+
+## 1. 目的・背景
+
+カテゴリ内の具体的な「プレイ可能な行動」を `Action` として定義し、ユーザー自身がカスタマイズできるようにする。プレイログ記録時の `actionId` 参照先となる。
+
+## 2. コンセプト / 設計思想
+
+カテゴリが「領域（勉強）」を表すのに対し、Action は「行動（30分問題集を解く）」を表す。`unit`（任意）を持たせることで「回」「分」「km」などの単位付き記録に拡張可能（Phase 2 ロードマップ）。Phase 1 では単純な `playCount` 集計を基本とする。
+
+## 3. スコープ
+
+### 含む（Phase 1）
+- Action CRUD のうち GET（一覧）と POST（作成）
+- `categoryId` 必須化によるスコープ強制
+- `visible` / `order` の管理
+- `unit` フィールド（空文字は `undefined` に変換）
+
+### 含まない（将来）
+- PATCH / DELETE
+- `unit` を活用した quantity 必須化（Phase 2: LIF-52 〜 LIF-54）
+- Action 単位の統計
+
+## 4. ユースケース / 主要フロー
+
+- 設定画面でカテゴリを選択 → そのカテゴリのアクション一覧を取得（`GET /api/actions?categoryId=...`）
+- 新規アクション追加（`POST /api/actions`）
+- プレイ登録画面では Category → Action の順でドリルダウン
+
+API シグネチャ・バリデーションは [`./spec.md`](./spec.md) を参照。
+
+## 5. 設計上の重要制約
+
+- `categoryId` は GET / POST 双方で必須（クエリ・ボディ）
+- `requireCategory(userId, categoryId)` で他ユーザーのカテゴリへの操作を 404 で防止
+- `label` は 1〜50 文字、`unit` は 0〜20 文字（空文字は null 化）
+- 一覧は `order` 昇順、同値は `id` 昇順で安定ソート
+
+## 関連ドキュメント
+
+- 詳細仕様: [./spec.md](./spec.md)
+- カテゴリ API: [`../category-api/overview.md`](../category-api/overview.md)
+- 全体アーキテクチャ: [`docs/architecture.md`](../architecture.md)
+- データモデル: [`docs/data-model.md`](../data-model.md)
+- 全体仕様（v1.0）: [`docs/spec_v1.0.md`](../spec_v1.0.md)

--- a/docs/action-api/spec.md
+++ b/docs/action-api/spec.md
@@ -1,0 +1,118 @@
+# Action API Specification
+
+> 詳細仕様。高位概要は [`./overview.md`](./overview.md) を参照。
+
+## 1. エンティティ定義
+
+### Action モデル（`prisma/schema.prisma`）
+
+| フィールド | 型 | デフォルト | 役割 |
+|----------|-----|-----------|------|
+| `id` | String (CUID) | 自動 | 主キー |
+| `categoryId` | String (FK) | — | 所属カテゴリ（Cascade） |
+| `userId` | String (FK) | — | 所有ユーザー（Cascade） |
+| `label` | String | — | 表示名（1〜50 文字） |
+| `unit` | String? | `null` | 単位（任意、0〜20 文字） |
+| `visible` | Boolean | `true` | 表示フラグ |
+| `order` | Int | `0` | 表示順 |
+| `createdAt` / `updatedAt` | DateTime | `now()` / 自動 | 監査 |
+
+**インデックス**: `@@index([userId, categoryId, visible, order])`
+
+**主要リレーション**: `User`, `Category`, `PlayLog[]`
+
+データモデル全体は [`docs/data-model.md`](../data-model.md) を参照。
+
+## 2. API 設計
+
+### エンドポイント一覧
+
+| Method | Path | 用途 | 認証 |
+|--------|------|------|------|
+| GET | `/api/actions` | 一覧取得 | 必須 |
+| POST | `/api/actions` | 新規作成 | 必須 |
+
+### `GET /api/actions`
+
+**クエリパラメータ**:
+- `categoryId`（必須、文字列）
+- `visible`（任意、`true` で表示中のみ）
+
+**ソート**: `order` 昇順 → `id` 昇順
+
+**レスポンス（200）**:
+```json
+{
+  "actions": [
+    { "id": "...", "categoryId": "...", "label": "30分問題集", "unit": "回", "visible": true, "order": 0, "createdAt": "...", "updatedAt": "..." }
+  ]
+}
+```
+
+### `POST /api/actions`
+
+**リクエスト**: `CreateActionInput`
+
+```json
+{
+  "categoryId": "cat-...",
+  "label": "30分問題集",
+  "unit": "回",
+  "visible": true,
+  "order": 0
+}
+```
+
+`unit`, `visible`, `order` は省略可。
+
+**レスポンス（201）**: `{ "action": Action }`
+
+### バリデーション
+
+スキーマ: `src/lib/validations/action.ts`
+
+| スキーマ | フィールド | 制約 |
+|---------|----------|------|
+| `getActionsQuerySchema` | `categoryId` | 1 文字以上、trim 必須 |
+|  | `visible` | クエリ文字列 → boolean 変換（"true" → `true`） |
+| `createActionSchema` | `categoryId` | 1 文字以上、trim |
+|  | `label` | 1〜50 文字、trim |
+|  | `unit` | 0〜20 文字、trim、空文字は `undefined` 化 |
+|  | `visible` | boolean（省略時 `true`） |
+|  | `order` | 整数（省略時 `0`） |
+
+## 3. ビジネスロジック
+
+- **categoryId 検証**: GET / POST で `requireCategory(userId, categoryId)` を呼び、所有権を確認。違反は 404
+- **`unit` 空文字対応**: Zod の前処理で空文字は `undefined` に変換し、DB では `null` として保存
+- **二段ソート**: `order` 昇順、`id` 昇順で安定。フロントの「並び順表示」前提
+- **`visible` フィルタ**: 設定画面では全件、プレイ登録画面では `visible=true` を渡し UI から非表示にできる
+
+## 4. エラーハンドリング
+
+| エラー | HTTP Status | code | 発生条件 |
+|--------|-------------|------|---------|
+| 認証エラー | 401 | `UNAUTHORIZED` | `requireUser()` 失敗 |
+| バリデーションエラー | 400 | `VALIDATION_ERROR` | クエリ・ボディ Zod エラー |
+| 未検出 | 404 | `NOT_FOUND` | `requireCategory` で対象カテゴリなし |
+| 内部エラー | 500 | `INTERNAL_ERROR` | DB エラー |
+
+## 5. 画面仕様
+
+| 画面 | パス | 主要操作 |
+|------|------|---------|
+| アクション管理 | `src/app/(main)/settings/actions/page.tsx` | カテゴリ選択 → 一覧 → 追加フォーム |
+
+`ActionForm` は既存アクションの最大 `order + 1` を `defaultOrder` として算出。
+
+## 6. テスト戦略
+
+- ユニット: `src/app/api/actions/__tests__/route.test.ts`
+- E2E: `e2e/action-management.spec.ts`
+- 重点カバー: `categoryId` 欠落 / `label` 境界 / `unit` 空文字 / `order` 整数バリデーション / 404
+
+## 更新履歴
+
+| 日付 | 変更内容 | 関連 PR |
+|------|---------|--------|
+| 2026-04-26 | 初版（LIF-66） | — |

--- a/docs/category-api/overview.md
+++ b/docs/category-api/overview.md
@@ -1,0 +1,48 @@
+# Category API Overview
+
+> 高位概要。詳細は [`./spec.md`](./spec.md) を参照。
+
+## 1. 目的・背景
+
+ユーザーが自由に「カテゴリ」を作成・管理できるカスタマイズ前提の設計を実現する。プレイログ・アクション・スキルツリー・週ランクなど、ほぼ全機能が `Category` を起点に紐づく中核エンティティ。
+
+## 2. コンセプト / 設計思想
+
+「人生 RPG 型システム」の基本単位。ユーザーの行動領域（例: 勉強・運動・読書）を抽象化し、それぞれに XP/SP の変換レート（`xpPerPlay`, `xpPerSp`）と週ランク判定期間（`rankWindowDays`）を持つ。デフォルト値は spec_v1.0 の基準（XP10, XP20=1SP, 7日）に従う。
+
+## 3. スコープ
+
+### 含む（Phase 1）
+- カテゴリ CRUD（GET / POST / PATCH）
+- 表示・非表示の切り替え（`visible`）
+- 表示順序の管理（`order`）
+- ユーザー単位の隔離（自分のカテゴリのみ操作可）
+
+### 含まない（将来）
+- カテゴリ削除（DELETE）API ※ Cascade を持つため要件確定後に追加
+- カテゴリの並び替え専用 API（現状はフロント側で `order` を計算）
+- カテゴリ単位の権限共有・公開
+
+## 4. ユースケース / 主要フロー
+
+- 設定画面でカテゴリ一覧を取得（`GET /api/categories`）
+- 「追加」ボタンから新規カテゴリ作成（`POST /api/categories`）
+- トグルで表示・非表示を切替（`PATCH /api/categories/[id]`）
+- 他機能（Action / Play / SkillTree）は `categoryId` で本 API のリソースを参照
+
+API シグネチャ・バリデーション・エラーは [`./spec.md`](./spec.md) を参照。
+
+## 5. 設計上の重要制約
+
+- 全リクエストで `requireUser()` による認証必須
+- カテゴリは必ず `userId` でフィルタ（他ユーザーのカテゴリへアクセス不可）
+- `xpPerPlay`, `xpPerSp`, `rankWindowDays` は 1 以上の整数（バリデーションで強制）
+- `name` は 1〜50 文字（trim 後）
+
+## 関連ドキュメント
+
+- 詳細仕様: [./spec.md](./spec.md)
+- 全体アーキテクチャ: [`docs/architecture.md`](../architecture.md)
+- データモデル: [`docs/data-model.md`](../data-model.md)
+- XP/SP 計算ロジック: [`docs/state-machine.md`](../state-machine.md)
+- 全体仕様（v1.0）: [`docs/spec_v1.0.md`](../spec_v1.0.md)

--- a/docs/category-api/spec.md
+++ b/docs/category-api/spec.md
@@ -1,0 +1,133 @@
+# Category API Specification
+
+> 詳細仕様。高位概要は [`./overview.md`](./overview.md) を参照。
+
+## 1. エンティティ定義
+
+### Category モデル（`prisma/schema.prisma`）
+
+| フィールド | 型 | デフォルト | 役割 |
+|----------|-----|-----------|------|
+| `id` | String (CUID) | 自動 | 主キー |
+| `userId` | String (FK) | — | 所有ユーザー（Cascade 削除） |
+| `name` | String | — | カテゴリ名（1〜50 文字） |
+| `visible` | Boolean | `true` | 表示フラグ |
+| `order` | Int | `0` | 表示順 |
+| `rankWindowDays` | Int | `7` | 週ランク判定期間（日） |
+| `xpPerPlay` | Int | `10` | 1 プレイあたり XP |
+| `xpPerSp` | Int | `20` | 1 SP に必要な XP |
+| `createdAt` / `updatedAt` | DateTime | `now()` / 自動 | 監査 |
+
+**インデックス**: `@@index([userId, visible, order])`
+
+**主要リレーション**: `Action[]`, `DailyCategoryResult[]`, `PlayerCategoryState`, `SkillTree[]`, `SeasonalTitle[]`, `SpendLog[]`
+
+データモデル全体は [`docs/data-model.md`](../data-model.md) と `prisma/schema.prisma` を参照。
+
+## 2. API 設計
+
+### エンドポイント一覧
+
+| Method | Path | 用途 | 認証 |
+|--------|------|------|------|
+| GET | `/api/categories` | 一覧取得 | 必須 |
+| POST | `/api/categories` | 新規作成 | 必須 |
+| PATCH | `/api/categories/[id]` | 更新（visible 切替） | 必須 |
+
+### `GET /api/categories`
+
+**クエリパラメータ**:
+- `visible=true`（任意）: `true` のカテゴリのみ取得
+
+**ソート**: `id` 昇順
+
+**レスポンス（200）**:
+```json
+{
+  "categories": [
+    { "id": "...", "userId": "...", "name": "勉強", "visible": true, "order": 0, "rankWindowDays": 7, "xpPerPlay": 10, "xpPerSp": 20, "createdAt": "...", "updatedAt": "..." }
+  ]
+}
+```
+
+### `POST /api/categories`
+
+**リクエスト**: `CreateCategoryInput`
+
+```json
+{
+  "name": "勉強",
+  "visible": true,
+  "order": 0,
+  "rankWindowDays": 7,
+  "xpPerPlay": 10,
+  "xpPerSp": 20
+}
+```
+
+`name` 以外は省略可（デフォルト適用）。
+
+**レスポンス（201）**: `{ "category": Category }`
+
+### `PATCH /api/categories/[id]`
+
+**リクエスト**: `UpdateCategoryInput`
+
+```json
+{ "visible": false }
+```
+
+**レスポンス（200）**: `{ "category": Category }`
+
+### バリデーション
+
+スキーマ: `src/lib/validations/category.ts`
+
+| スキーマ | フィールド | 制約 |
+|---------|----------|------|
+| `createCategorySchema` | `name` | 1〜50 文字、trim 後必須 |
+|  | `visible` | boolean、省略時 `true` |
+|  | `order` | 整数、省略時 `0` |
+|  | `rankWindowDays` | 1 以上の整数、省略時 `7` |
+|  | `xpPerPlay` | 1 以上の整数、省略時 `10` |
+|  | `xpPerSp` | 1 以上の整数、省略時 `20` |
+| `updateCategorySchema` | `visible` | boolean（任意） |
+| `categoryIdParamSchema` | `id` | 1 文字以上 |
+
+## 3. ビジネスロジック
+
+- **ユーザー隔離**: `requireUser()` で取得した `userId` で必ず WHERE 句に追加
+- **`visible` フィルタ**: クエリ `visible=true` 指定時のみ表示中カテゴリへ絞り込む。デフォルトは全件返却
+- **デフォルト値の根拠**: `xpPerPlay=10`, `xpPerSp=20` は spec_v1.0 の基準（[`docs/spec_v1.0.md`](../spec_v1.0.md)）。`rankWindowDays=7` は週ランクの標準ウィンドウ
+- **関連ヘルパー**: `src/lib/api/requireCategory.ts` — 他 API（Action / Play / SkillTree）でのカテゴリ所有権検証に使用
+
+## 4. エラーハンドリング
+
+| エラー | HTTP Status | code | 発生条件 |
+|--------|-------------|------|---------|
+| 認証エラー | 401 | `UNAUTHORIZED` | `requireUser()` 失敗 |
+| バリデーションエラー | 400 | `VALIDATION_ERROR` | Zod エラー（`formatZodError`） |
+| 未検出 | 404 | `NOT_FOUND` | PATCH 時、id 該当なし（`formatNotFoundError('カテゴリ', id)`） |
+| 内部エラー | 500 | `INTERNAL_ERROR` | DB エラーなど（`formatInternalError`） |
+
+エラーフォーマッタ: `src/lib/validations/helpers.ts`
+
+## 5. 画面仕様
+
+| 画面 | パス | 主要操作 |
+|------|------|---------|
+| カテゴリ管理 | `src/app/(main)/settings/categories/page.tsx` | 一覧表示・追加・visible トグル |
+
+UI コンポーネント: `src/components/settings/category-form.tsx`（`CategoryForm`）。トースト通知で成否をフィードバック。
+
+## 6. テスト戦略
+
+- ユニット: `src/app/api/categories/__tests__/route.test.ts`, `src/app/api/categories/[id]/__tests__/route.test.ts`
+- E2E: `e2e/category-management.spec.ts`
+- 重点カバー: 認証 / `visible` フィルタ / バリデーション境界（`name` 51 文字、`xpPerPlay=0` 等） / 404 ハンドリング
+
+## 更新履歴
+
+| 日付 | 変更内容 | 関連 PR |
+|------|---------|--------|
+| 2026-04-26 | 初版（LIF-66） | — |

--- a/docs/daily-confirmation/overview.md
+++ b/docs/daily-confirmation/overview.md
@@ -1,0 +1,50 @@
+# Daily Confirmation Overview
+
+> 高位概要。詳細は [`./spec.md`](./spec.md) を参照。
+
+## 1. 目的・背景
+
+その日のプレイログを「確定」（`draft → confirmed`）し、`DailyCategoryResult` の XP/SP を `PlayerCategoryState` の累計に加算する処理。RPG における「日次セーブ」に相当し、以降そのデータは不変となる。
+
+## 2. コンセプト / 設計思想
+
+- **確定後は不変**: 一度 `confirmed` になった日付は再計算されない。誤りがあっても修正は別タスクとして扱う
+- **未来日付の禁止**: 当日より未来は確定不可（`FutureDateError`）
+- **二重確定の防止**: `AlreadyConfirmedError` で再確定を拒否（オプションで許可可）
+- **トランザクション原子性**: XP/SP 計算と累計加算は 1 つのトランザクション内
+
+## 3. スコープ
+
+### 含む（Phase 1）
+- `POST /api/results/[dayKey]/confirm` による明示確定
+- `confirmDay()` ドメイン関数によるトランザクション処理
+- `GET /api/results/[dayKey]` での状態取得（過去日の自動確定オプション含む）
+
+### 含まない（将来）
+- 確定済み日付の取り消し（unconfirm）
+- バッチによる自動確定（cron）
+- 確定通知・メール
+
+## 4. ユースケース / 主要フロー
+
+- リザルト画面で「日次確定」ボタンを押下 → `POST /api/results/[dayKey]/confirm`
+- 確定後は当画面で確定済み表示、ボタン非表示
+- `confirmDay` は SP の累計を `PlayerCategoryState.spUnspent` へ加算 → スキルツリーのノード解放原資となる
+
+API シグネチャ・副作用順序は [`./spec.md`](./spec.md) を参照。
+
+## 5. 設計上の重要制約
+
+- 全リクエストで `requireUser()` 認証必須
+- `dayKey` は `YYYY-MM-DD` + 実在日付チェック（`isValidDayKey`）
+- 当日の `dayKey` は `getTodayKey()` 基準。未来は `FutureDateError`（422）
+- 既確定の再確定は `AlreadyConfirmedError`（422）。`allowAlreadyConfirmed` オプションで上書き許可可
+- トランザクション中の任意の失敗で全ロールバック（中途半端な累計加算を防ぐ）
+
+## 関連ドキュメント
+
+- 詳細仕様: [./spec.md](./spec.md)
+- プレイログ: [`../play-log/overview.md`](../play-log/overview.md)
+- 状態遷移: [`docs/state-machine.md`](../state-machine.md)
+- データモデル: [`docs/data-model.md`](../data-model.md)
+- 全体仕様（v1.0）: [`docs/spec_v1.0.md`](../spec_v1.0.md)

--- a/docs/daily-confirmation/spec.md
+++ b/docs/daily-confirmation/spec.md
@@ -1,0 +1,110 @@
+# Daily Confirmation Specification
+
+> 詳細仕様。高位概要は [`./overview.md`](./overview.md) を参照。
+
+## 1. エンティティ定義
+
+`DailyResult`, `DailyCategoryResult`, `PlayerCategoryState` を扱う。スキーマ詳細は [`../play-log/spec.md`](../play-log/spec.md) §1 と [`docs/data-model.md`](../data-model.md) を参照。
+
+| 状態 | 意味 |
+|------|------|
+| `DailyResult.status = 'draft'` | プレイ登録のみ。XP/SP 未確定 |
+| `DailyResult.status = 'confirmed'` | 確定済み。`PlayerCategoryState` に累計加算済み |
+
+## 2. API 設計
+
+### エンドポイント一覧
+
+| Method | Path | 用途 | 認証 |
+|--------|------|------|------|
+| GET | `/api/results/[dayKey]` | 当日リザルト取得（過去日の自動確定オプションあり） | 必須 |
+| POST | `/api/results/[dayKey]/confirm` | 明示確定 | 必須 |
+
+### `POST /api/results/[dayKey]/confirm`
+
+**パスパラメータ**: `dayKey`（`YYYY-MM-DD`）
+
+**リクエストボディ**: なし
+
+**レスポンス（200）**: `{ "ok": true }`
+
+**副作用**: 後述 `confirmDay` 参照
+
+### `GET /api/results/[dayKey]`
+
+**レスポンス（200）**:
+```json
+{
+  "dailyResult": { "userId": "...", "dayKey": "...", "status": "draft", "confirmedAt": null },
+  "categoryResults": [{ "categoryId": "...", "playCount": 3, "xpEarned": 30, "spEarned": 1 }]
+}
+```
+
+過去日付かつ `status === 'draft'` の場合、環境変数で自動確定オプトインがあると `confirmDay` を実行する。
+
+### バリデーション
+
+スキーマ: `src/lib/validations/result.ts`
+
+| スキーマ | フィールド | 制約 |
+|---------|----------|------|
+| `dayKeyParamSchema` | `dayKey` | `YYYY-MM-DD` 正規表現 + `isValidDate` |
+
+## 3. ドメイン関数
+
+### `confirmDay(userId, dayKey, options?)` — `src/lib/domains/confirm.ts`
+
+**シグネチャ**:
+```ts
+async function confirmDay(
+  userId: string,
+  dayKey: string,
+  options?: { allowAlreadyConfirmed?: boolean }
+): Promise<DailyResult>
+```
+
+**処理順序（トランザクション内）**:
+
+1. **未来日付チェック**: `dayKey > getTodayKey()` → `FutureDateError`
+2. `DailyResult` を `(userId, dayKey)` で取得 or 作成
+3. **既確定チェック**: `status === 'confirmed'` かつ `!allowAlreadyConfirmed` → `AlreadyConfirmedError`
+4. その日の `DailyCategoryResult` 一覧を取得
+5. 各 categoryResult に対して:
+   - `xpEarned = calculateXpEarned(playCount, category.xpPerPlay)`
+   - `spEarned = calculateSpFromXp(xpEarned, category.xpPerSp)`
+   - `DailyCategoryResult.update`
+   - `PlayerCategoryState.upsert`（`xpTotal += xpEarned`, `spUnspent += spEarned`）
+6. `DailyResult.update`（`status = 'confirmed'`, `confirmedAt = now()`）
+
+任意のステップで例外発生時は全ロールバック。
+
+## 4. エラーハンドリング
+
+| エラー | HTTP Status | code | 発生条件 |
+|--------|-------------|------|---------|
+| 認証エラー | 401 | `UNAUTHORIZED` | `requireUser()` 失敗 |
+| バリデーションエラー | 400 | `VALIDATION_ERROR` | `dayKey` 形式不正 |
+| 未来日付 | 422 | `FUTURE_DATE` | `FutureDateError`（`formatInvalidOperationError`） |
+| 既確定 | 422 | `ALREADY_CONFIRMED` | `AlreadyConfirmedError` |
+| 内部エラー | 500 | `INTERNAL_ERROR` | DB / トランザクション失敗 |
+
+エラークラスは `src/lib/domains/errors.ts`、フォーマッタは `src/lib/validations/helpers.ts`。
+
+## 5. 画面仕様
+
+| 画面 | パス | 主要操作 |
+|------|------|---------|
+| リザルト | `src/app/(main)/result/page.tsx` | 確定ボタン押下 → API 呼び出し |
+
+確定済み日付ではボタン非表示。確定成功時はトースト通知。
+
+## 6. テスト戦略
+
+- ユニット: `src/app/api/results/__tests__/confirm.test.ts`, `src/lib/domains/__tests__/confirm.test.ts`
+- 重点カバー: 未来日付拒否 / 既確定拒否 / 当日許可 / 過去日許可 / `PlayerCategoryState` 累計加算の正確性 / トランザクションロールバック
+
+## 更新履歴
+
+| 日付 | 変更内容 | 関連 PR |
+|------|---------|--------|
+| 2026-04-26 | 初版（LIF-66） | — |

--- a/docs/play-log/overview.md
+++ b/docs/play-log/overview.md
@@ -1,0 +1,48 @@
+# Play Log Overview
+
+> 高位概要。詳細は [`./spec.md`](./spec.md) を参照。
+
+## 1. 目的・背景
+
+ユーザーの行動を「プレイ」として記録する中核機能。プレイログの作成・取得・削除を提供し、記録と同時に当日の `DailyResult` / `DailyCategoryResult` を upsert することで、未確定 XP/SP の即時表示を可能にする。
+
+## 2. コンセプト / 設計思想
+
+「成長の即時フィードバック」を実現するため、プレイ登録時に集計データもトランザクション内で更新する設計。日次確定（`/spec/daily-confirmation/`）はこの集計済みデータを `confirmed` 状態へ遷移させるだけで、二重計算を避ける。
+
+確定済み日付に対するプレイ登録は **翌日へ自動繰り越し**（`getNextDayKey`）する。これは spec_v1.0 の「確定後は不変」の原則を守るための制約。
+
+## 3. スコープ
+
+### 含む（Phase 1）
+- `POST /api/plays`（作成 + 集計 upsert）
+- `GET /api/plays`（dayKey でフィルタ取得）
+- `DELETE /api/plays/[id]`（未確定時のみ）
+
+### 含まない（将来）
+- プレイログの編集（PUT/PATCH）
+- `quantity`（数量）を必須化した量重視ロジック（Phase 2: LIF-52〜LIF-54）
+- バルク登録
+
+## 4. ユースケース / 主要フロー
+
+- プレイ登録画面でカテゴリ → アクション → 数量・備考を入力 → POST
+- リザルト画面で当日のプレイログ一覧と未確定 XP/SP を表示（GET）
+- 未確定日のプレイログを削除すると DailyCategoryResult が再計算される
+
+確定処理は別機能（[`../daily-confirmation/overview.md`](../daily-confirmation/overview.md)）。
+
+## 5. 設計上の重要制約
+
+- POST はトランザクション内で `DailyResult` upsert → `PlayLog` create → `DailyCategoryResult` upsert を実行
+- 既に `confirmed` の日付に対する POST は **翌日 dayKey** へ繰り越し（`getNextDayKey`）
+- GET は `userId` で必ず絞り込む（横断アクセス不可）
+- `dayKey` は `YYYY-MM-DD` 形式かつ実在日付（`isValidDayKey` でチェック）
+
+## 関連ドキュメント
+
+- 詳細仕様: [./spec.md](./spec.md)
+- 日次確定: [`../daily-confirmation/overview.md`](../daily-confirmation/overview.md)
+- 状態遷移・XP/SP 計算ロジック: [`docs/state-machine.md`](../state-machine.md)
+- データモデル: [`docs/data-model.md`](../data-model.md)
+- 全体仕様（v1.0）: [`docs/spec_v1.0.md`](../spec_v1.0.md)

--- a/docs/play-log/spec.md
+++ b/docs/play-log/spec.md
@@ -1,0 +1,116 @@
+# Play Log Specification
+
+> 詳細仕様。高位概要は [`./overview.md`](./overview.md) を参照。
+
+## 1. エンティティ定義
+
+### 主要モデル（`prisma/schema.prisma`）
+
+| モデル | 主要フィールド | 制約・備考 |
+|--------|--------------|-----------|
+| `PlayLog` | `id`, `at`, `dayKey`, `actionId`, `userId`, `quantity?`, `note?`, `createdAt` | `@@index([userId, dayKey])`, `@@index([userId, actionId])` |
+| `DailyResult` | `[userId, dayKey]` 複合主キー, `status` (`draft`/`confirmed`), `confirmedAt?` | プレイ登録で upsert |
+| `DailyCategoryResult` | `id`, `dayKey`, `categoryId`, `userId`, `playCount`, `xpEarned`, `spEarned` | `@@unique([userId, dayKey, categoryId])` |
+| `PlayerCategoryState` | `id`, `categoryId`, `userId`, `xpTotal`, `spUnspent` | `categoryId` に `@unique` |
+
+データモデル全体は [`docs/data-model.md`](../data-model.md)、状態遷移は [`docs/state-machine.md`](../state-machine.md) を参照。
+
+## 2. API 設計
+
+### エンドポイント一覧
+
+| Method | Path | 用途 | 認証 |
+|--------|------|------|------|
+| GET | `/api/plays` | 一覧取得 | 必須 |
+| POST | `/api/plays` | 新規記録 | 必須 |
+| DELETE | `/api/plays/[id]` | 削除（未確定時のみ） | 必須 |
+
+### `GET /api/plays`
+
+**クエリパラメータ**:
+- `dayKey`（必須、`YYYY-MM-DD`）
+- `categoryId`（任意）
+
+**レスポンス（200）**:
+```json
+{ "playLogs": [{ "id": "...", "at": "...", "dayKey": "2026-04-26", "actionId": "...", "quantity": 3, "note": "問題集 1.1", "createdAt": "..." }] }
+```
+
+### `POST /api/plays`
+
+**リクエスト**: `CreatePlayInput`
+
+```json
+{ "actionId": "act-...", "quantity": 3, "note": "問題集 1.1" }
+```
+
+**レスポンス（201）**: `{ "playLog": PlayLog }`
+
+**副作用**（トランザクション内）:
+1. `DailyResult` を `(userId, dayKey)` で取得 or 作成
+2. `confirmed` 状態なら `dayKey = getNextDayKey(dayKey)` で翌日に繰り越し
+3. `PlayLog.create`
+4. `DailyCategoryResult` を `(userId, dayKey, categoryId)` で upsert（`playCount += 1`、未確定 XP/SP 再計算）
+
+### `DELETE /api/plays/[id]`
+
+未確定日（`status === 'draft'`）の `PlayLog` を削除し、`DailyCategoryResult` を再計算。
+
+**レスポンス（200）**: `{ "ok": true }`
+**エラー**: 422（確定済み日付の削除）/ 404 / 401
+
+### バリデーション
+
+スキーマ: `src/lib/validations/play.ts`
+
+| スキーマ | フィールド | 制約 |
+|---------|----------|------|
+| `getPlaysQuerySchema` | `dayKey` | `dayKeySchema`（YYYY-MM-DD + 実在チェック） |
+|  | `categoryId` | 任意 |
+| `createPlaySchema` | `actionId` | 必須、文字列 |
+|  | `quantity` | 任意、1 以上の整数 |
+|  | `note` | 任意、文字列 |
+| `playIdParamSchema` | `id` | 必須 |
+
+## 3. ビジネスロジック
+
+- **集計の一貫性**: POST トランザクション内で `PlayLog` と `DailyCategoryResult` を同時更新。中途半端な状態を作らない
+- **翌日繰り越し**: 確定済み日付への POST は `getNextDayKey` で `dayKey` を再計算（[`docs/state-machine.md`](../state-machine.md) §「確定後プレイの翌日回し」参照）
+- **XP/SP の即時計算**: `DailyCategoryResult.xpEarned` は未確定段階で `calculateXpEarned(playCount, xpPerPlay)` を反映、`spEarned` は `calculateSpFromXp(xpEarned, xpPerSp)`
+- **削除時の再計算**: DELETE は `playCount -= 1` と XP/SP の再算出を行う（確定済みは拒否）
+
+### 関連ユーティリティ
+
+- `src/lib/calculation/xp.ts` — `calculateXpEarned`, `calculateXpUntilNextSp`, `calculateXpProgressPercent`
+- `src/lib/calculation/sp.ts` — `calculateSpFromXp`, `hasEnoughSp`
+- `src/lib/date/day-key.ts` — `getTodayKey`, `getNextDayKey`, `getPreviousDayKey`, `isValidDayKey`, `parseDayKey`, `formatDayLabel`
+
+## 4. エラーハンドリング
+
+| エラー | HTTP Status | code | 発生条件 |
+|--------|-------------|------|---------|
+| 認証エラー | 401 | `UNAUTHORIZED` | `requireUser()` 失敗 |
+| バリデーションエラー | 400 | `VALIDATION_ERROR` | Zod エラー |
+| 確定済み削除 | 422 | `INVALID_OPERATION` | DELETE で `confirmed` 日付 |
+| アクション未検出 | 404 | `NOT_FOUND` | `actionId` 該当なし |
+| 内部エラー | 500 | `INTERNAL_ERROR` | DB エラー |
+
+## 5. 画面仕様
+
+| 画面 | パス | 主要操作 |
+|------|------|---------|
+| プレイ登録 | `src/app/(main)/play/page.tsx` | カテゴリ → アクション → 数量・備考入力 → POST |
+| 当日リザルト | `src/app/(main)/result/page.tsx` | 当日プレイログ表示・未確定 XP/SP 表示・削除 |
+
+UI 詳細は [`docs/ux-spec.md`](../ux-spec.md) §「プレイ画面」「リザルト画面」を参照。
+
+## 6. テスト戦略
+
+- ユニット: `src/app/api/plays/__tests__/route.test.ts`, `src/lib/calculation/__tests__/xp.test.ts`, `src/lib/calculation/__tests__/sp.test.ts`, `src/lib/date/__tests__/day-key.test.ts`
+- 重点カバー: 認証 / dayKey 必須 / 確定済み日付の翌日繰り越し / 削除の再計算
+
+## 更新履歴
+
+| 日付 | 変更内容 | 関連 PR |
+|------|---------|--------|
+| 2026-04-26 | 初版（LIF-66） | — |

--- a/docs/skill-tree-node-unlock/overview.md
+++ b/docs/skill-tree-node-unlock/overview.md
@@ -1,0 +1,52 @@
+# Skill Tree & Node Unlock Overview
+
+> 高位概要。詳細は [`./spec.md`](./spec.md) を参照。
+
+## 1. 目的・背景
+
+確定後の SP（`PlayerCategoryState.spUnspent`）を消費して、カテゴリ別の「恒久称号（スキルツリー）」のノードを段階的に解放していく機能。RPG のスキルツリーに相当し、長期成長の可視化と動機付けを担う。
+
+## 2. コンセプト / 設計思想
+
+- **段階解放**: 各 `SkillTree` 内のノードは `order` で順序付けされ、前ノードを解放しないと次が解放できない（`PrerequisiteNotMetError`）
+- **不可逆**: 一度解放したノードは取り消せない（`UnlockedNode` の複合一意制約で重複防止）
+- **SP の追跡**: `SpendLog` で `type='unlock_node'` として履歴残し、カテゴリ別に集計可能
+- **状態は 3 値**: UI では `locked` / `unlockable` / `unlocked` の 3 状態で表現（`getSkillNodeState`）
+
+## 3. スコープ
+
+### 含む（Phase 1）
+- スキルツリー一覧取得（`GET /api/skills/trees`）
+- ノード一覧取得（`GET /api/skills/nodes`、解放状態付与）
+- ノード解放（`POST /api/skills/nodes/[id]/unlock`）
+- UI: 3 ステップ操作（カテゴリ → ツリー → ノード）
+
+### 含まない（将来）
+- ノード解放の取り消し（refund）
+- ツリー / ノードの管理 UI（admin）
+- 横断スキルツリー（カテゴリをまたぐ）
+
+## 4. ユースケース / 主要フロー
+
+- スキル画面でカテゴリ → スキルツリー → ノードの順に選択
+- 解放ダイアログで `costSp` と現状 SP、前提条件を表示 → 「解放」押下
+- API が事前条件 5 段（ノード存在 / 重複 / PlayerState / SP / 前提）を順序検証 → トランザクションで `spUnspent` 減算 + `UnlockedNode` 作成 + `SpendLog` 作成
+- 完了後、ツリー画面が状態を更新
+
+API・エラー・UI 詳細は [`./spec.md`](./spec.md) を参照。
+
+## 5. 設計上の重要制約
+
+- **トランザクション原子性**: `PlayerCategoryState` decrement → `UnlockedNode` create → `SpendLog` create を 1 トランザクション。任意の失敗で全ロールバック
+- **複合一意制約**: `UnlockedNode @@unique([userId, nodeId])` により同時並行 POST でも重複解放しない（DB レベル保証）
+- **順序制約**: `order > 1` のノードは前ノード（`order - 1`）が解放済みでなければ `PrerequisiteNotMetError`
+- **SP 不足検知**: `spUnspent < costSp` で `InsufficientSpError`（`required` / `available` を返却）
+- **認証**: 全リクエストで `requireUser()` 必須
+
+## 関連ドキュメント
+
+- 詳細仕様: [./spec.md](./spec.md)
+- 状態遷移ロジック: [`docs/state-machine.md`](../state-machine.md)
+- データモデル: [`docs/data-model.md`](../data-model.md)
+- UI 設計: [`docs/ux-spec.md`](../ux-spec.md), [`docs/design-system.md`](../design-system.md)
+- 全体仕様（v1.0）: [`docs/spec_v1.0.md`](../spec_v1.0.md)

--- a/docs/skill-tree-node-unlock/spec.md
+++ b/docs/skill-tree-node-unlock/spec.md
@@ -1,0 +1,163 @@
+# Skill Tree & Node Unlock Specification
+
+> 詳細仕様。高位概要は [`./overview.md`](./overview.md) を参照。
+
+## 1. エンティティ定義
+
+### 主要モデル（`prisma/schema.prisma`）
+
+| モデル | 主要フィールド | 制約・備考 |
+|--------|--------------|-----------|
+| `SkillTree` | `id`, `categoryId`, `userId`, `name`, `visible`, `order` | `@@index([userId, categoryId, visible, order])` |
+| `SkillNode` | `id`, `treeId`, `userId`, `order`, `title`, `costSp` | `@@unique([userId, treeId, order])` |
+| `UnlockedNode` | `id`, `nodeId`, `userId`, `unlockedAt` | `@@unique([userId, nodeId])`, `@@index([userId, unlockedAt])` |
+| `SpendLog` | `id`, `at`, `categoryId`, `userId`, `type`, `costSp`, `refId`, `dayKey?` | `@@index([userId, categoryId, at])` |
+| `PlayerCategoryState` | `id`, `categoryId`, `userId`, `xpTotal`, `spUnspent` | `categoryId` に `@unique` |
+
+`SpendLog.type` は `unlock_node` 固定（定数 `SPEND_LOG_TYPE.UNLOCK_NODE`）、`refId` は `nodeId` を保持。
+
+データモデル全体は [`docs/data-model.md`](../data-model.md) を参照。
+
+## 2. API 設計
+
+### エンドポイント一覧
+
+| Method | Path | 用途 | 認証 |
+|--------|------|------|------|
+| GET | `/api/skills/trees` | カテゴリ配下のツリー一覧 | 必須 |
+| GET | `/api/skills/nodes` | ツリー配下のノード一覧（解放状態付与） | 必須 |
+| POST | `/api/skills/nodes/[id]/unlock` | ノード解放 | 必須 |
+
+### `GET /api/skills/trees`
+
+**クエリ**: `categoryId`（必須）, `visible`（任意）
+
+**レスポンス（200）**:
+```json
+{ "trees": [{ "id": "...", "categoryId": "...", "name": "...", "visible": true, "order": 0, "createdAt": "...", "updatedAt": "..." }] }
+```
+
+### `GET /api/skills/nodes`
+
+**クエリ**: `treeId`（必須）
+
+**レスポンス（200）**:
+```json
+{
+  "nodes": [
+    { "id": "...", "treeId": "...", "order": 1, "title": "...", "costSp": 5, "isUnlocked": false, "unlockedAt": null, "createdAt": "...", "updatedAt": "..." }
+  ]
+}
+```
+
+`isUnlocked`, `unlockedAt` は `mapNodeWithUnlockStatus`（`src/lib/mappers/skillNode.ts`）が付与。
+
+### `POST /api/skills/nodes/[id]/unlock`
+
+**パスパラメータ**: `id`（nodeId）
+
+**リクエストボディ**: なし
+
+**レスポンス（200）**:
+```json
+{ "unlockedNode": { "id": "...", "nodeId": "...", "unlockedAt": "..." } }
+```
+
+副作用は後述の `unlockNode` を参照。
+
+### バリデーション
+
+スキーマ: `src/lib/validations/skill.ts`（共通ヘルパー `requiredId` を使用）
+
+| スキーマ | 主なフィールド |
+|---------|--------------|
+| `skillTreesQuerySchema` | `categoryId`（必須） |
+| `skillTreeIdParamSchema` | `id`（必須） |
+| `skillNodesQuerySchema` | `treeId`（必須） |
+| `skillNodeIdParamSchema` | `id`（必須） |
+
+## 3. ドメイン関数
+
+### `unlockNode(userId, nodeId)` — `src/lib/domains/skill.ts`
+
+**シグネチャ**:
+```ts
+async function unlockNode(userId: string, nodeId: string): Promise<{
+  unlockedNode: { id: string; nodeId: string; unlockedAt: Date };
+  costSp: number;
+  categoryId: string;
+  treeId: string;
+}>
+```
+
+**事前条件チェック（順序）**:
+1. `SkillNode` 存在確認 → 失敗で `SkillNodeNotFoundError`
+2. `UnlockedNode.length > 0` チェック → 既存で `AlreadyUnlockedError`
+3. `PlayerCategoryState` 存在確認 → 失敗で `PlayerStateNotFoundError`
+4. `spUnspent >= costSp` → 不足で `InsufficientSpError(required, available, nodeId)`
+5. `order > 1` の場合、前ノード（`order - 1`）解放確認 → 失敗で `PrerequisiteNotMetError(prerequisiteNodeId)`
+
+**トランザクション内処理（順序）**:
+1. `PlayerCategoryState.update` で `spUnspent -= costSp`
+2. `UnlockedNode.create`（`@@unique([userId, nodeId])` で並行重複防止）
+3. `SpendLog.create`（`type=unlock_node`, `refId=nodeId`, `costSp`）
+
+任意のステップで失敗時はトランザクション全ロールバック。
+
+## 4. 状態計算 / マッパー
+
+### `getSkillNodeState(node, previousNode, spUnspent)` — `src/lib/skills/skill-node-state.ts`
+
+**戻り値**: `'locked' | 'unlockable' | 'unlocked'`
+
+| 条件 | 結果 |
+|------|------|
+| `node.isUnlocked === true` | `unlocked` |
+| `order === 1` かつ `spUnspent >= costSp` | `unlockable` |
+| `order > 1` かつ前ノード解放済み かつ `spUnspent >= costSp` | `unlockable` |
+| 上記以外 | `locked` |
+
+### `mapNodeWithUnlockStatus(node)` — `src/lib/mappers/skillNode.ts`
+
+`UnlockedNode[]` を集約し、API レスポンス用に `isUnlocked`（boolean）と `unlockedAt`（Date or null）を付与。
+
+## 5. エラーハンドリング
+
+| エラー | HTTP Status | code | 発生条件 |
+|--------|-------------|------|---------|
+| 認証エラー | 401 | `UNAUTHORIZED` | `requireUser()` 失敗 |
+| バリデーションエラー | 400 | `VALIDATION_ERROR` | Zod エラー |
+| ノード未検出 | 404 | `SKILL_NODE_NOT_FOUND` | `SkillNodeNotFoundError` |
+| プレイヤーステート未検出 | 404 | `PLAYER_STATE_NOT_FOUND` | `PlayerStateNotFoundError` |
+| 重複解放 | 400 | `ALREADY_UNLOCKED` | `AlreadyUnlockedError` |
+| SP 不足 | 400 | `INSUFFICIENT_SP` | `InsufficientSpError`（`details: { required, available, nodeId }`） |
+| 前提未達 | 400 | `PREREQUISITE_NOT_MET` | `PrerequisiteNotMetError`（`details: { prerequisiteNodeId }`） |
+| 内部エラー | 500 | `INTERNAL_ERROR` | トランザクション失敗 |
+
+エラーフォーマッタ: `src/lib/validations/helpers.ts`
+
+## 6. 画面仕様
+
+| 画面・コンポーネント | パス | 役割 |
+|--------------------|------|------|
+| スキルツリー画面 | `src/app/(main)/skills/page.tsx` | カテゴリ → ツリー → ノードの 3 ステップ統合 |
+| ツリー表示 | `src/components/skills/skill-tree-view.tsx` | ノード配列を order 順表示、キーボード操作 |
+| 解放ダイアログ | `src/components/skills/node-unlock-dialog.tsx` | コスト・現 SP・前提条件表示、解放実行 |
+
+UI 設計指針は [`docs/design-system.md`](../design-system.md) と [`docs/ux-spec.md`](../ux-spec.md) を参照。
+
+## 7. テスト戦略
+
+- ユニット: `src/lib/domains/__tests__/skill.test.ts`, `src/lib/__tests__/skill-node-state.test.ts`
+- UI: `src/components/skills/__tests__/skill-steps.test.tsx`
+- 重点カバー:
+  - 5 段階の事前条件チェックそれぞれの失敗ケース
+  - 並行解放での `@@unique` による重複防止
+  - SP 不足時の details 返却
+  - 状態計算 6 ケース（解放済み / order=1 SP 充分・不足 / order>1 前解放有無 × SP 充分・不足）
+
+## 更新履歴
+
+| 日付 | 変更内容 | 関連 PR |
+|------|---------|--------|
+| 2026-04-26 | 初版（LIF-66） | — |


### PR DESCRIPTION
## Summary

PR #92 で追加した `spec-doc` Skill のテンプレ／ワークフローを検証するため、対象 4 機能（5 feature ディレクトリ）の `overview.md` + `spec.md` を生成。

## 検証対象

| Feature | ディレクトリ |
|---------|------------|
| Category API | `docs/category-api/` |
| Action API | `docs/action-api/` |
| プレイログ | `docs/play-log/` |
| 日次確定 | `docs/daily-confirmation/` |
| スキルツリー・ノード解放 | `docs/skill-tree-node-unlock/` |

## 検証で得た所見（SKILL.md フィードバックは PR #92 に追記）

1. **テンプレが詳細仕様向き**: Category / Action のような小規模 CRUD では「画面仕様」「状態遷移」を削除すると締まる。テンプレに「該当しない章は削除前提」のマーカーを追加すべき
2. **既存 docs への参照集中化**: `data-model.md`, `state-machine.md`, `ux-spec.md` への相対リンクを各 spec で多用。冗長な再記述は避け、要点抜粋＋参照に留める方針が有効
3. **feature 間相互リンク**: `play-log` ↔ `daily-confirmation` のように密結合な機能はテンプレに「関連 feature リンク」枠を増やすと網羅しやすい
4. **エラーハンドリング表は実装と同期しやすい形**: HTTP Status / code / 発生条件の 3 列が運用しやすい

## 関連

- 親 issue: LIF-65（HITL 型ドキュメント自動更新システム）
- 同 issue: LIF-66（Phase 1）DoD-3 / DoD-4 該当
- 依存: #92（Skill 本体）, #93（CLAUDE.md / AGENTS.md 方針）

## Test plan

- [ ] 各 `overview.md` が 1〜2 ページに収まっているか
- [ ] 各 `spec.md` の API シグネチャ・エラー・データモデルが実装と一致するか
- [ ] テンプレ未使用章が残っていないか
- [ ] 既存フラット構成 docs（`architecture.md` 等）に変更が入っていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)